### PR TITLE
Disables itself when used in a file:// page

### DIFF
--- a/instantclick.js
+++ b/instantclick.js
@@ -193,10 +193,6 @@ var InstantClick = function(document, location) {
 
 
   function instantanize(isInitializing) {
-    if(location.protocol == "file:") {
-        return; // Don't start when using file:// urls. It just makes links glitch out, and local links are fast enough
-    }
-
     var as = document.getElementsByTagName('a'),
         a,
         domain = location.protocol + '//' + location.host
@@ -379,7 +375,7 @@ var InstantClick = function(document, location) {
     'pushState' in history && (
       !$ua.match('Android') ||
       $ua.match('Chrome/')
-    )
+    ) && (location.protocol != "file:") // Don't start when using file:// urls. It just makes links glitch out, and local links are fast enough
   )
   /* The state of Android's AOSP browsers:
 


### PR DESCRIPTION
This change was made because when somebody tries to use a page with instantclick.js via a file:// url, all the links sort of glitch out. They require you to click twice and don't add any speed improvements.
