### PR TITLE
Add "dom" event

### DIFF
--- a/instantclick.js
+++ b/instantclick.js
@@ -28,6 +28,7 @@ var InstantClick = function(document, location) {
         fetch: [],
         receive: [],
         wait: [],
+        dom: [],
         change: []
       }
 
@@ -120,6 +121,7 @@ var InstantClick = function(document, location) {
     else {
       scrollTo(0, scrollY)
     }
+    triggerPageEvent('dom', false)
     instantanize()
     bar.done()
     triggerPageEvent('change', false)
@@ -626,6 +628,8 @@ var InstantClick = function(document, location) {
 
     $xhr = new XMLHttpRequest()
     $xhr.addEventListener('readystatechange', readystatechange)
+
+    triggerPageEvent('dom', true)
 
     instantanize(true)
 


### PR DESCRIPTION
New "dom" event will be triggered just after HTML gets updated and before
internal "instantanize" function gets called.

This event is useful in at least case (that I've come across).
It's when you don't want to update HTML directly and rather rely on JS.

Example:

``` JS
!function($, ic, u) {
  var updateDom, hrefPattern;

  hrefPattern = /no\/reload/; // change me

  updateDom = function() {
    $('a:not([data-instant]):not([data-no-instant])').each(function() {
      if (!this.href.match(hrefPattern)) {
        return;
      }

      $(this).data('data-instant', '');
    });
  }

  ic.on('dom', updateDom);
  ic.init(true);
} (jQuery, InstantClick);
```
