### PR TITLE
FIX wrong URL in pushState if server redirects XHR request to another adress

### DIFF
--- a/instantclick.js
+++ b/instantclick.js
@@ -201,6 +201,7 @@ var InstantClick = function(document, location) {
       doc.documentElement.innerHTML = $xhr.responseText
       $title = doc.title
       $body = doc.body
+      $url = $xhr.responseURL;
       var urlWithoutHash = removeHash($url)
       $history[urlWithoutHash] = {
         body: $body,


### PR DESCRIPTION
$url should be the one returned by server if XHR has done loaded page content.

My case: user session has been expired, all the requests to server have been redirected to login page. I don't know why but the login form failed to submit becasue of wrong URL. First submit failed and send nothing to server. Then browser load the actual login page with the right one URL. User have to submit again.
