### PR TITLE
Add an install.json

### DIFF
--- a/install.json
+++ b/install.json
@@ -1,0 +1,30 @@
+{
+  "resources": {
+    "body": [
+      {
+        "type": "script",
+        "src": "./instantclick.js"
+      },
+      {
+        "type": "script",
+        "contents": "InstantClick.init(); if (INSTALL_OPTIONS.progressBar !== true) { document.head.insertAdjacentHTML('beforeend', '<style>#instantclick { display: none; }</style>'); } else { if (INSTALL_OPTIONS.progressBarColor) { document.head.insertAdjacentHTML('beforeend', '<style>#instantclick-bar { background-color: ' + INSTALL_OPTIONS.progressBarColor + '; }</style>'); } }"
+      }
+    ]
+  },
+  "options": {
+    "properties": {
+      "progressBar": {
+        "title": "Show progress bar",
+        "description": "When navigating from one page to another, show a loading progress bar at the top of the page.",
+        "type": "boolean"
+      },
+      "progressBarColor": {
+        "title": "Progress bar color",
+        "description": "The color of the progress bar. (Requires \"Show progress bar\" to be checked.)",
+        "type": "string",
+        "format": "color",
+        "default": "#2299dd"
+      }
+    }
+  }
+}


### PR DESCRIPTION
_Thanks so much for creating this amazing app! I recently added it to my website and it has made things much faster._

---

This PR adds an `install.json` file to define how InstantClick app can be “installed” on websites. At the moment, `install.json` files are consumed only by the Eager App Store.

In the interim, I’ve added InstantClick to the store [store.eager.io/app/ZYBle8qUhKFJ](https://store.eager.io/app/ZYBle8qUhKFJ) by manually supplying the Install JSON. But moving forward, it’s beneficial to have it in the repo so it can change as releases change. (The Eager App Store follows SemVer versioning of apps.)

You can view Eager’s [Developer Docs](https://github.com/EagerIO/DeveloperDocs/blob/master/docs/adding-your-app.md#install-json) for more information on `install.json`.
