### PR TITLE
Load scripts synchronously

### DIFF
--- a/instantclick.js
+++ b/instantclick.js
@@ -241,6 +241,40 @@ var InstantClick = function(document, location) {
 
   ////////// MAIN FUNCTIONS //////////
 
+  function syncload(scripts, i) {
+    var script,
+        copy,
+        parentNode,
+        nextSibling
+    if (i < scripts.length) {
+      script = scripts[i]
+      if (script.hasAttribute('data-no-instant')) {
+        syncload(scripts, i + 1)
+        return
+      }
+      copy = document.createElement('script')
+      if (script.src) {
+        copy.src = script.src
+      }
+      if (script.innerHTML) {
+        copy.innerHTML = script.innerHTML
+      }
+      parentNode = script.parentNode
+      nextSibling = script.nextSibling
+      parentNode.removeChild(script)
+      parentNode.insertBefore(copy, nextSibling)
+      // real browsers:
+      copy.onload = function() {
+        syncload(scripts, i + 1)
+      }
+      // internet explorer:
+      copy.onreadystatechange = function() {
+        if (this.readyState == 'complete') {
+          syncload(scripts, i + 1)
+        }
+      }
+    }
+  }
 
   function instantanize(isInitializing) {
     var as = document.getElementsByTagName('a'),
@@ -270,29 +304,7 @@ var InstantClick = function(document, location) {
       a.addEventListener('click', click)
     }
     if (!isInitializing) {
-      var scripts = document.body.getElementsByTagName('script'),
-          script,
-          copy,
-          parentNode,
-          nextSibling
-
-      for (i = 0, j = scripts.length; i < j; i++) {
-        script = scripts[i]
-        if (script.hasAttribute('data-no-instant')) {
-          continue
-        }
-        copy = document.createElement('script')
-        if (script.src) {
-          copy.src = script.src
-        }
-        if (script.innerHTML) {
-          copy.innerHTML = script.innerHTML
-        }
-        parentNode = script.parentNode
-        nextSibling = script.nextSibling
-        parentNode.removeChild(script)
-        parentNode.insertBefore(copy, nextSibling)
-      }
+      syncload(document.body.getElementsByTagName('script'), 0)
     }
   }
 


### PR DESCRIPTION
External scripts were being asynchronously loaded as part of the new page being loaded. This could break inlined scripts that depended on such scripts.

Example:

```
<script src="http://example.com/external_methods.js"></script>
<script>external_method();</script>
```

This pull request fixes this problem by waiting for scripts to load before inserting the remaining `script` elements.
