### PR TITLE
Expose instantanize function publically

### DIFF
--- a/instantclick.js
+++ b/instantclick.js
@@ -687,7 +687,8 @@ var InstantClick = function(document, location) {
     // debug: debug,
     supported: supported,
     init: init,
-    on: on
+    on: on,
+    instantanize: instantanize
   }
 
 }(document, location);


### PR DESCRIPTION
InstantClick currently doesn't support any kind of 'live' binding of elements, e.g. if you add <a> elements to the DOM after InstantClick has been initialised, those elements will not be correctly set-up as InstantClick-enabled.

Exposing instantanize() means one can enable InstantClick for elements added after InstantClick.init() - by calling InstantClick.instantanize() after elements have been added to the DOM.
