### PR TITLE
Add support for user callback to swap new content into the DOM

### DIFF
--- a/instantclick.js
+++ b/instantclick.js
@@ -134,7 +134,7 @@ var InstantClick = function(document, location) {
 
   function changePage(title, body, newUrl, scrollY) {
     if ($changePageCallback) {
-      $changePageCallback(body, !!newUrl)
+      $changePageCallback(body)
     } else {
       document.documentElement.replaceChild(body, document.body)
     }
@@ -145,26 +145,23 @@ var InstantClick = function(document, location) {
     if (newUrl) {
       history.pushState(null, null, newUrl)
 
-      if (!$changePageCallback) {
-        var hashIndex = newUrl.indexOf('#'),
-            hashElem = hashIndex > -1
-                       && document.getElementById(newUrl.substr(hashIndex + 1)),
-            offset = 0
+      var hashIndex = newUrl.indexOf('#'),
+          hashElem = hashIndex > -1
+                     && document.getElementById(newUrl.substr(hashIndex + 1)),
+          offset = 0
 
-        if (hashElem) {
-          while (hashElem.offsetParent) {
-            offset += hashElem.offsetTop
-  
-            hashElem = hashElem.offsetParent
-          }
+      if (hashElem) {
+        while (hashElem.offsetParent) {
+          offset += hashElem.offsetTop
+
+          hashElem = hashElem.offsetParent
         }
-      
-        scrollTo(0, offset)
       }
-      
+      scrollTo(0, offset)
+
       $currentLocationWithoutHash = removeHash(newUrl)
     }
-    else if (!$changePageCallback) {
+    else {
       scrollTo(0, scrollY)
     }
 


### PR DESCRIPTION
Hi Alex - I found InstantClick when it was on Hacker News last year.  Awesome idea, and I finally had a chance to try it out for a site I'm working on and I love it.

I'd like to be able to customize how the new content replaces the old content.  Specifically, I want to swap out the contents of a single div rather than the entire document (which is already in your backlog as issue #105) and also fade it in.

To allow this, I modified the code to accept a pageChangeCallback that accepts the new body content.  If this is specified, InstantClicks calls it, rather than inserting the new content into the DOM.  As an example, here is the callback I'm using for my personal website (www.joestrommen.com):

    InstantClick.init(function (newBody) {
        // Keep everything other than body-content intact
        var $newBodyContent = $(newBody).find(".body-content");
        $(".body-content").replaceWith($newBodyContent);
        var opacity = $newBodyContent.css('opacity'); // Force a re-calc
        $newBodyContent.removeClass("fade-in");
    });

To support this, I also had to modify the history tracking to store the HTML text rather than the body DOM object and title (in my scenario the DOM body is never actually swapped out, so restoring it on Back doesn't actually restore any content).  Another consequence of this change is that going Back/Forward with InstantClick will restore the DOM to how it was when that page was loaded, rather than how it was when a link was clicked.  This is more consistent with browser Back/Forward, so I think this is a good thing.

Also - I was unable to get the tests running.  I get `PHP Notice:  Undefined variable: append in /home/joe/instantclick/tests/index.php on line 53`, and the PHP code just shows up in the browser.  I've never used PHP so it's likely I'm screwing something up.  Any ideas?

Thanks for creating InstantClick, and let me know if you have any feedback.
Joe