### PR TITLE
fix safari html parse error

### DIFF
--- a/instantclick.js
+++ b/instantclick.js
@@ -276,6 +276,17 @@ var InstantClick = function(document, location) {
     setPreloadingAsHalted()
   }
 
+  function createDocumentUsingFragment(html) {
+    var body, doc, head, htmlWrapper, ref, ref1;
+    head = ((ref = html.match(/<head[^>]*>([\s\S.]*)<\/head>/i)) != null ? ref[0] : void 0) || '<head></head>';
+    body = ((ref1 = html.match(/<body[^>]*>([\s\S.]*)<\/body>/i)) != null ? ref1[0] : void 0) || '<body></body>';
+    htmlWrapper = document.createElement('html')
+    htmlWrapper.innerHTML = head + body;
+    doc = document.createDocumentFragment()
+    doc.appendChild(htmlWrapper)
+    return doc
+  };
+
   function readystatechange() {
     if ($xhr.readyState < 4) {
       return
@@ -288,10 +299,10 @@ var InstantClick = function(document, location) {
     $timing.ready = +new Date - $timing.start
 
     if ($xhr.getResponseHeader('Content-Type').match(/\/(x|ht|xht)ml/)) {
-      var doc = document.implementation.createHTMLDocument('')
-      doc.documentElement.innerHTML = removeNoscriptTags($xhr.responseText)
-      $title = doc.title
-      $body = doc.body
+      var doc = createDocumentUsingFragment(removeNoscriptTags($xhr.responseText))
+      var title = doc.querySelector('title')
+      $title = title != null ? title.textContent : null;
+      $body = doc.querySelector('body')
 
       var alteredOnReceive = triggerPageEvent('receive', $url, $body, $title)
       if (alteredOnReceive) {
@@ -310,7 +321,7 @@ var InstantClick = function(document, location) {
         scrollY: urlWithoutHash in $history ? $history[urlWithoutHash].scrollY : 0
       }
 
-      var elems = doc.head.children,
+      var elems = doc.querySelector('head').children,
           found = 0,
           elem,
           data


### PR DESCRIPTION
Cribbed this fix from turbolinks. Here's the bug:

https://github.com/rails/turbolinks/issues/408

It seems Safari has problems parsing the xhr text leading to some weird rendering bugs (in my case it was nesting sibling nodes). This resolved it for me in instant click.
