### PR TITLE
Fix bug in removing noscript tags

### DIFF
--- a/instantclick.js
+++ b/instantclick.js
@@ -187,7 +187,7 @@ var InstantClick = function(document, location) {
     /* Must be done on text, not on a node's innerHTML, otherwise strange
      * things happen with implicitly closed elements (see the Noscript test).
      */
-    return html.replace(/<noscript[\s\S]+<\/noscript>/gi, '')
+    return html.replace(/<noscript[\s\S]+?<\/noscript>/gi, '')
   }
 
 

--- a/tests/pages/noscript.html
+++ b/tests/pages/noscript.html
@@ -5,3 +5,5 @@
 <noscript><p style="background: red; color: white;">This should not display. Well, unless you disabled JavaScript.</noscript>
 
 <p>If you don’t see a <span style="background: red; color: white;">red</span> paragraph above this one, you’re good.
+
+<noscript><p style="background: red; color: white;">This should not display. Well, unless you disabled JavaScript.</noscript>


### PR DESCRIPTION
The regex that Instantclick uses to strip `<noscript>` tags is greedy. That means, on a page with multiple `<noscript>` tags, everything between the first opening `noscript`, and the last closing `noscript`, gets stripped.

E.g., markup like this:

```
A <noscript>B</noscript> C <noscript>D</noscript> E
```

Is rendered as:

```
A E
```

When of course it should be:

```
A C E
```

The fix is trivial, one character to make the quantifier non-greedy:

```
return html.replace(/<noscript[\s\S]+<\/noscript>/gi, '')
```

Should be

```
return html.replace(/<noscript[\s\S]+?<\/noscript>/gi, '')
```

I've also taken the liberty of updating the appropriate test page.