### PR TITLE
Fix issue #134: Prevent same link being added to history API

### DIFF
--- a/src/instantclick.js
+++ b/src/instantclick.js
@@ -113,7 +113,9 @@ var instantClick
     */
 
     if (newUrl) {
-      history.pushState(null, null, newUrl)
+      if (location.href !== newUrl){
+        history.pushState(null, null, newUrl)
+      }
 
       var hashIndex = newUrl.indexOf('#')
         , hashElem = hashIndex > -1


### PR DESCRIPTION
Fixes: https://github.com/dieulot/instantclick/issues/134

Prevents the same link being added to history API. Currently clicking on the same link multiple times gets added to your browser history each time.

@dieulot 

