### PR TITLE
FIXED: using go back button on browser to go back on landing page now…

### DIFF
--- a/src/instantclick.js
+++ b/src/instantclick.js
@@ -544,7 +544,7 @@ var instantClick
 
     $currentLocationWithoutHash = removeHash(location.href)
     $history[$currentLocationWithoutHash] = {
-      body: document.body,
+      body: (document.body).cloneNode(true),
       title: document.title,
       scrollY: pageYOffset
     }


### PR DESCRIPTION
… works as it should MODIFIED: on init write history's body attribute with hard copy of document.body instead of reference
