### PR TITLE
Simulate DOMContentLoaded

### DIFF
--- a/src/instantclick.js
+++ b/src/instantclick.js
@@ -180,6 +180,11 @@ var instantClick
       instantanize(false)
 
       triggerPageEvent('change', false)
+      
+      // Simulate DOMContentLoaded
+	    var DOMContentLoaded_event = document.createEvent("Event")
+	    DOMContentLoaded_event.initEvent("DOMContentLoaded", true, true)
+	    window.document.dispatchEvent(DOMContentLoaded_event)
     }
     else {
       /* On popstate, browsers scroll by themselves, but at least Firefox


### PR DESCRIPTION
Certains scripts se basent sur l’événement "DOMContentLoaded" pour s’exécuter, le fait qu'InstantClick ne le simule pas provoque des dysfonctionnements avec ces scripts, ce commit règle le problème.