### PR TITLE
Auto-execute InstantClick when the page is ready

### DIFF
--- a/src/instantclick.js
+++ b/src/instantclick.js
@@ -810,3 +810,8 @@ var instantClick
   }
 
 }(document, location, navigator.userAgent);
+
+// Auto-launch when DOM content is loaded
+document.addEventListener('DOMContentLoaded', function() {
+	InstantClick.init();
+});


### PR DESCRIPTION
Il est toujours nécessaire de faire un InstantClick.init(); à la main en dehors de la librairie, je propose qu'il soit lancé de base, et si on ne veux pas le charger, il suffirai de ne pas inclure le fichier javascript.