### PR TITLE
Turn Instantclick into a module if it needs to be one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 build
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "instantclick",
+  "version": "4.0.0",
+  "description": "InstantClick makes following links in your website instant.",
+  "main": "src/instantclick.js",
+  "directories": {
+    "test": "tests"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dieulot/instantclick.git"
+  },
+  "keywords": [
+    "pjax"
+  ],
+  "author": "dieulot",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/dieulot/instantclick/issues"
+  },
+  "homepage": "http://instantclick.io/"
+}

--- a/src/instantclick.js
+++ b/src/instantclick.js
@@ -967,3 +967,15 @@ var instantclick
   }
 
 }(document, location, navigator.userAgent);
+
+(function (root, InstantClick) {
+    if (typeof define === 'function' && define.amd) {
+        define([], InstantClick);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = InstantClick;
+    } else {
+        root.returnExports = InstantClick;
+  }
+}(this, function () {
+    return InstantClick;
+}));

--- a/src/instantclick.js
+++ b/src/instantclick.js
@@ -976,6 +976,4 @@ var instantclick
     } else {
         root.returnExports = InstantClick;
   }
-}(this, function () {
-    return InstantClick;
-}));
+}(this, InstantClick));


### PR DESCRIPTION
A lot of web developers use RequireJs, Browserify or the like, so this PR enables Instantclick to be ```require```-d or ```import```-ed from Javascript and Typescript entry points.  
  
Regular functionality is the same. If the script runs plainly in the browser, it will attach the InstantClick object to ```window``` as usual.  
  
I also added a package.json to let people do ```npm install https://github.com/dieulot/instantclick``` and be on their way.

> **I wrote the version number as ```4.0.0```, so that probably needs to be changed before merging into master.**